### PR TITLE
Use the correct port for the masterserver

### DIFF
--- a/apps/master/main.cpp
+++ b/apps/master/main.cpp
@@ -13,7 +13,7 @@ bool run = true;
 
 int main()
 {
-    masterServer.reset(new MasterServer(2000, 25560));
+    masterServer.reset(new MasterServer(2000, 25561));
     restServer.reset(new RestServer(8080, masterServer->GetServers()));
 
     auto onExit = [](int /*sig*/){


### PR DESCRIPTION
I removed the legacy code that changed the port if attempting to connect to a tes3mp version < 0.6 here: #6

However, tes3mp has code to handle going from 25560 -> 25561, however this only works if you use the official master server:
https://github.com/MWMadness/S3-MP/blob/master/apps/browser/main.cpp#L41-L42
https://github.com/MWMadness/S3-MP/blob/master/apps/openmw-mp/main.cpp#L285-L292

So TLDR: This pr fixes the default port for our masterserver

Edit: The default port in tes3mp-client-default.cfg also specifies `25561`