### PR TITLE
0.7.1 cell records

### DIFF
--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
@@ -1530,6 +1530,41 @@ void RecordsDynamicFunctions::SetRecordFog(unsigned int red, unsigned int green,
     tempOverrides.hasFog = true;
 }
 
+void RecordsDynamicFunctions::SetRecordHasWater(bool hasWater) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        if(hasWater)
+            tempCell.data.mData.mFlags |= ESM::Cell::Flags::HasWater;
+        else
+            tempCell.data.mData.mFlags &= ~ESM::Cell::Flags::HasWater;
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set ambient color for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasHasWater = true;
+}
+
+void RecordsDynamicFunctions::SetRecordWaterLevel(double waterLevel) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        tempCell.data.mWater = waterLevel;
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set ambient color for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasWaterLevel = true;
+}
+
 void RecordsDynamicFunctions::SetRecordIdByIndex(unsigned int index, const char* id) noexcept
 {
     unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
@@ -1478,7 +1478,7 @@ void RecordsDynamicFunctions::SetRecordHasAmbient(bool hasAmbi) noexcept
         return;
     }
 
-    tempOverrides.hasHasAmbi = true;
+    tempOverrides.hasAmbiState = true;
 }
 
 void RecordsDynamicFunctions::SetRecordAmbientColor(unsigned int red, unsigned int green, unsigned int blue) noexcept
@@ -1546,7 +1546,7 @@ void RecordsDynamicFunctions::SetRecordHasWater(bool hasWater) noexcept
         return;
     }
 
-    tempOverrides.hasHasWater = true;
+    tempOverrides.hasWaterState = true;
 }
 
 void RecordsDynamicFunctions::SetRecordWaterLevel(double waterLevel) noexcept

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 
 #include "RecordsDynamic.hpp"
+#include "Utils.hpp"
 
 using namespace std;
 using namespace mwmp;
@@ -735,16 +736,11 @@ void RecordsDynamicFunctions::SetRecordAutoCalc(int autoCalc) noexcept
         tempEnchantment.data.mData.mAutocalc = autoCalc;
     else if (writeRecordsType == mwmp::RECORD_TYPE::NPC)
     {
+        Utils::setFlag(tempNpc.data.mFlags, ESM::NPC::Autocalc, autoCalc);
         if (autoCalc)
-        {
-            tempNpc.data.mFlags |= ESM::NPC::Autocalc;
             tempNpc.data.mNpdtType = ESM::NPC::NPC_WITH_AUTOCALCULATED_STATS;
-        }
         else
-        {
-            tempNpc.data.mFlags &= ~ESM::NPC::Autocalc;
             tempNpc.data.mNpdtType = ESM::NPC::NPC_DEFAULT;
-        }
     }
     else
     {
@@ -1535,10 +1531,7 @@ void RecordsDynamicFunctions::SetRecordHasWater(bool hasWater) noexcept
     unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
 
     if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
-        if(hasWater)
-            tempCell.data.mData.mFlags |= ESM::Cell::Flags::HasWater;
-        else
-            tempCell.data.mData.mFlags &= ~ESM::Cell::Flags::HasWater;
+        Utils::setFlag(tempCell.data.mData.mFlags, ESM::Cell::Flags::HasWater, hasWater);
     }
     else
     {

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
@@ -1558,6 +1558,55 @@ void RecordsDynamicFunctions::SetRecordWaterLevel(double waterLevel) noexcept
     tempOverrides.hasWaterLevel = true;
 }
 
+void RecordsDynamicFunctions::SetRecordNoSleep(bool noSleep) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        Utils::setFlag(tempCell.data.mData.mFlags, ESM::Cell::Flags::NoSleep, noSleep);
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set no sleep state for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasNoSleep = true;
+}
+
+void RecordsDynamicFunctions::SetRecordQuasiEx(bool quasiEx) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        Utils::setFlag(tempCell.data.mData.mFlags, ESM::Cell::Flags::QuasiEx, quasiEx);
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set quasi exterior state for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasQuasiEx = true;
+}
+
+void RecordsDynamicFunctions::SetRecordRegion(const char* region) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        tempCell.data.mRegion = region;
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set quasi exterior state for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasRegion = true;
+}
+
+
 void RecordsDynamicFunctions::SetRecordIdByIndex(unsigned int index, const char* id) noexcept
 {
     unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.cpp
@@ -1465,6 +1465,71 @@ void RecordsDynamicFunctions::SetRecordScriptText(const char* scriptText) noexce
     tempOverrides.hasScriptText = true;
 }
 
+void RecordsDynamicFunctions::SetRecordHasAmbient(bool hasAmbi) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        tempCell.data.mHasAmbi = hasAmbi;
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set has ambient for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasHasAmbi = true;
+}
+
+void RecordsDynamicFunctions::SetRecordAmbientColor(unsigned int red, unsigned int green, unsigned int blue) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        tempCell.data.mAmbi.mAmbient = red + (green << 8) + (blue << 16);
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set ambient color for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasAmbientColor = true;
+}
+
+void RecordsDynamicFunctions::SetRecordSunlightColor(unsigned int red, unsigned int green, unsigned int blue) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        tempCell.data.mAmbi.mSunlight = red + (green << 8) + (blue << 16);
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set ambient color for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasSunlightColor = true;
+}
+
+void RecordsDynamicFunctions::SetRecordFog(unsigned int red, unsigned int green, unsigned int blue, double density) noexcept
+{
+    unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;
+
+    if (writeRecordsType == mwmp::RECORD_TYPE::CELL) {
+        tempCell.data.mAmbi.mFog = red + (green << 8) + (blue << 16);
+        tempCell.data.mAmbi.mFogDensity = density;
+    }
+    else
+    {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_ERROR, "Tried to set ambient color for record type %i which lacks that property", writeRecordsType);
+        return;
+    }
+
+    tempOverrides.hasFog = true;
+}
+
 void RecordsDynamicFunctions::SetRecordIdByIndex(unsigned int index, const char* id) noexcept
 {
     unsigned short writeRecordsType = WorldstateFunctions::writeWorldstate.recordsType;

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
@@ -110,6 +110,9 @@
     {"SetRecordFog",                            RecordsDynamicFunctions::SetRecordFog},\
     {"SetRecordHasWater",                       RecordsDynamicFunctions::SetRecordHasWater},\
     {"SetRecordWaterLevel",                     RecordsDynamicFunctions::SetRecordWaterLevel},\
+    {"SetRecordNoSleep",                        RecordsDynamicFunctions::SetRecordNoSleep},\
+    {"SetRecordQuasiEx",                        RecordsDynamicFunctions::SetRecordQuasiEx},\
+    {"SetRecordRegion",                         RecordsDynamicFunctions::SetRecordRegion},\
     \
     {"SetRecordIdByIndex",                      RecordsDynamicFunctions::SetRecordIdByIndex},\
     {"SetRecordEnchantmentIdByIndex",           RecordsDynamicFunctions::SetRecordEnchantmentIdByIndex},\
@@ -937,6 +940,31 @@ public:
     * \return void
     */
     static void SetRecordWaterLevel(double waterLevel) noexcept;
+
+    /**
+    * \brief Set whether players are allowed to sleep in the temporary record
+    * stored on the server for the currently specified record type.
+    *
+    * \param noSleep Whether players are allowed to sleep
+    * \return void
+    */
+    static void SetRecordNoSleep(bool noSleep) noexcept;
+
+    /**
+    * \brief Set whether the temporary record stored on the server for the
+    * currently specified record type is a quasi exterior.
+    * \param quasiEx Whether the record is a quasi exterior.
+    * \return void
+    */
+    static void SetRecordQuasiEx(bool quasiEx) noexcept;
+
+    /**
+    * \brief Set region of the temporary record stored on the server for the
+    * currently specified record type.
+    * \param region The region of the record
+    * \return void
+    */
+    static void SetRecordRegion(const char* region) noexcept;
 
     /**
     * \brief Set the id of the record at a certain index in the records stored on the server.

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
@@ -108,6 +108,8 @@
     {"SetRecordAmbientColor",                   RecordsDynamicFunctions::SetRecordAmbientColor},\
     {"SetRecordSunlightColor",                  RecordsDynamicFunctions::SetRecordSunlightColor},\
     {"SetRecordFog",                            RecordsDynamicFunctions::SetRecordFog},\
+    {"SetRecordHasWater",                       RecordsDynamicFunctions::SetRecordHasWater},\
+    {"SetRecordWaterLevel",                     RecordsDynamicFunctions::SetRecordWaterLevel},\
     \
     {"SetRecordIdByIndex",                      RecordsDynamicFunctions::SetRecordIdByIndex},\
     {"SetRecordEnchantmentIdByIndex",           RecordsDynamicFunctions::SetRecordEnchantmentIdByIndex},\
@@ -917,6 +919,24 @@ public:
     * \return void
     */
     static void SetRecordFog(unsigned int red, unsigned int green, unsigned int blue, double density) noexcept;
+
+    /**
+    * \brief Set the has water of the temporary record stored on the server for the
+    * currently specified record type.
+    *
+    * \param hasWater Has water of the record
+    * \return void
+    */
+    static void SetRecordHasWater(bool hasWater) noexcept;
+
+    /**
+    * \brief Set the water level of the temporary record stored on the server for the
+    * currently specified record type.
+    *
+    * \param waterLevel waterLevel of the record
+    * \return void
+    */
+    static void SetRecordWaterLevel(double waterLevel) noexcept;
 
     /**
     * \brief Set the id of the record at a certain index in the records stored on the server.

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
@@ -104,6 +104,11 @@
     \
     {"SetRecordScriptText",                     RecordsDynamicFunctions::SetRecordScriptText},\
     \
+    {"SetRecordHasAmbient",                     RecordsDynamicFunctions::SetRecordHasAmbient},\
+    {"SetRecordAmbientColor",                   RecordsDynamicFunctions::SetRecordAmbientColor},\
+    {"SetRecordSunlightColor",                  RecordsDynamicFunctions::SetRecordSunlightColor},\
+    {"SetRecordFog",                            RecordsDynamicFunctions::SetRecordFog},\
+    \
     {"SetRecordIdByIndex",                      RecordsDynamicFunctions::SetRecordIdByIndex},\
     {"SetRecordEnchantmentIdByIndex",           RecordsDynamicFunctions::SetRecordEnchantmentIdByIndex},\
     \
@@ -875,6 +880,43 @@ public:
     * \return void
     */
     static void SetRecordScriptText(const char* scriptText) noexcept;
+
+    /**
+    * \brief Set the has ambient of the temporary record stored on the server for the
+    * currently specified record type.
+    *
+    * \param bool Has ambient of the record
+    * \return void
+    */
+    static void SetRecordHasAmbient(bool hasAmbi) noexcept;
+
+    /**
+    * \brief Set the ambient color of the temporary record stored on the server for the
+    * currently specified record type.
+    *
+    * \param color Ambient color of the record
+    * \return void
+    */
+    static void SetRecordAmbientColor(unsigned int red, unsigned int green, unsigned int blue) noexcept;
+
+    /**
+    * \brief Set the sunlight color of the temporary record stored on the server for the
+    * currently specified record type.
+    *
+    * \param color Sunlight color of the record
+    * \return void
+    */
+    static void SetRecordSunlightColor(unsigned int red, unsigned int green, unsigned int blue) noexcept;
+
+    /**
+    * \brief Set the fog of the temporary record stored on the server for the
+    * currently specified record type.
+    *
+    * \param color Fog color of the record
+    * \param density Fog density of the record 
+    * \return void
+    */
+    static void SetRecordFog(unsigned int red, unsigned int green, unsigned int blue, double density) noexcept;
 
     /**
     * \brief Set the id of the record at a certain index in the records stored on the server.

--- a/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
+++ b/apps/openmw-mp/Script/Functions/RecordsDynamic.hpp
@@ -884,10 +884,10 @@ public:
     static void SetRecordScriptText(const char* scriptText) noexcept;
 
     /**
-    * \brief Set the has ambient of the temporary record stored on the server for the
+    * \brief Set the ambient state of the temporary record stored on the server for the
     * currently specified record type.
     *
-    * \param bool Has ambient of the record
+    * \param bool Ambient state of the record
     * \return void
     */
     static void SetRecordHasAmbient(bool hasAmbi) noexcept;
@@ -921,10 +921,10 @@ public:
     static void SetRecordFog(unsigned int red, unsigned int green, unsigned int blue, double density) noexcept;
 
     /**
-    * \brief Set the has water of the temporary record stored on the server for the
+    * \brief Set the water state of the temporary record stored on the server for the
     * currently specified record type.
     *
-    * \param hasWater Has water of the record
+    * \param hasWater Water state of the record
     * \return void
     */
     static void SetRecordHasWater(bool hasWater) noexcept;

--- a/apps/openmw/mwmp/RecordHelper.cpp
+++ b/apps/openmw/mwmp/RecordHelper.cpp
@@ -361,10 +361,21 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
             finalData.mAmbi.mFog = recordData.mAmbi.mFog;
             finalData.mAmbi.mFogDensity = recordData.mAmbi.mFogDensity;
         }
+        if (record.baseOverrides.hasHasWater) {
+            bool hasWater = recordData.mData.mFlags & ESM::Cell::Flags::HasWater;
+            if (hasWater)
+                finalData.mData.mFlags |= ESM::Cell::Flags::HasWater;
+            else
+                finalData.mData.mFlags &= ~ESM::Cell::Flags::HasWater;
+        }
+        if (record.baseOverrides.hasWaterLevel) {
+            finalData.mWater = recordData.mWater;
+        }
 
         world->unloadCell(finalData);
         world->clearCellStore(finalData);
         world->getModifiableStore().overrideRecord(finalData);
+
     }
     else
     {

--- a/apps/openmw/mwmp/RecordHelper.cpp
+++ b/apps/openmw/mwmp/RecordHelper.cpp
@@ -351,6 +351,17 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
         finalData.mName = recordData.mName;
         finalData.mCellId.mWorldspace = Misc::StringUtils::lowerCase(recordData.mName);
 
+        if (record.baseOverrides.hasHasAmbi)
+            finalData.mHasAmbi= recordData.mHasAmbi;
+        if (record.baseOverrides.hasAmbientColor)
+            finalData.mAmbi.mAmbient = recordData.mAmbi.mAmbient;
+        if (record.baseOverrides.hasSunlightColor)
+            finalData.mAmbi.mSunlight = recordData.mAmbi.mSunlight;
+        if (record.baseOverrides.hasFog) {
+            finalData.mAmbi.mFog = recordData.mAmbi.mFog;
+            finalData.mAmbi.mFogDensity = recordData.mAmbi.mFogDensity;
+        }
+
         world->unloadCell(finalData);
         world->clearCellStore(finalData);
         world->getModifiableStore().overrideRecord(finalData);

--- a/apps/openmw/mwmp/RecordHelper.cpp
+++ b/apps/openmw/mwmp/RecordHelper.cpp
@@ -351,7 +351,7 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
         finalData.mName = recordData.mName;
         finalData.mCellId.mWorldspace = Misc::StringUtils::lowerCase(recordData.mName);
 
-        if (record.baseOverrides.hasHasAmbi)
+        if (record.baseOverrides.hasAmbiState)
             finalData.mHasAmbi= recordData.mHasAmbi;
         if (record.baseOverrides.hasAmbientColor)
             finalData.mAmbi.mAmbient = recordData.mAmbi.mAmbient;
@@ -361,7 +361,7 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
             finalData.mAmbi.mFog = recordData.mAmbi.mFog;
             finalData.mAmbi.mFogDensity = recordData.mAmbi.mFogDensity;
         }
-        if (record.baseOverrides.hasHasWater) {
+        if (record.baseOverrides.hasWaterState) {
             bool hasWater = recordData.mData.mFlags & ESM::Cell::Flags::HasWater;
             if (hasWater)
                 finalData.mData.mFlags |= ESM::Cell::Flags::HasWater;

--- a/apps/openmw/mwmp/RecordHelper.cpp
+++ b/apps/openmw/mwmp/RecordHelper.cpp
@@ -372,6 +372,23 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
         if (record.baseOverrides.hasWaterLevel) {
             finalData.mWater = recordData.mWater;
         }
+        if (record.baseOverrides.hasNoSleep) {
+            Utils::setFlag(
+                finalData.mData.mFlags,
+                ESM::Cell::Flags::NoSleep,
+                recordData.mData.mFlags
+            );
+        }
+        if (record.baseOverrides.hasQuasiEx) {
+            Utils::setFlag(
+                finalData.mData.mFlags,
+                ESM::Cell::Flags::QuasiEx,
+                recordData.mData.mFlags
+            );
+        }
+        if (record.baseOverrides.hasRegion) {
+            finalData.mRegion = recordData.mRegion;
+        }
 
         world->unloadCell(finalData);
         world->clearCellStore(finalData);

--- a/apps/openmw/mwmp/RecordHelper.cpp
+++ b/apps/openmw/mwmp/RecordHelper.cpp
@@ -4,6 +4,7 @@
 #include "../mwworld/worldimp.hpp"
 
 #include "RecordHelper.hpp"
+#include <apps/openmw-mp/Utils.hpp>
 
 void RecordHelper::overrideRecord(const mwmp::ActivatorRecord& record)
 {
@@ -337,7 +338,7 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
 
     if (record.baseId.empty())
     {
-        recordData.mData.mFlags |= ESM::Cell::Flags::Interior;
+        Utils::setFlag(recordData.mData.mFlags, ESM::Cell::Flags::Interior, true);
         recordData.mCellId.mWorldspace = Misc::StringUtils::lowerCase(recordData.mName);
 
         world->unloadCell(recordData);
@@ -362,11 +363,11 @@ void RecordHelper::overrideRecord(const mwmp::CellRecord& record)
             finalData.mAmbi.mFogDensity = recordData.mAmbi.mFogDensity;
         }
         if (record.baseOverrides.hasWaterState) {
-            bool hasWater = recordData.mData.mFlags & ESM::Cell::Flags::HasWater;
-            if (hasWater)
-                finalData.mData.mFlags |= ESM::Cell::Flags::HasWater;
-            else
-                finalData.mData.mFlags &= ~ESM::Cell::Flags::HasWater;
+            Utils::setFlag(
+                finalData.mData.mFlags,
+                ESM::Cell::Flags::HasWater,
+                recordData.mData.mFlags
+            );
         }
         if (record.baseOverrides.hasWaterLevel) {
             finalData.mWater = recordData.mWater;
@@ -1061,11 +1062,7 @@ void RecordHelper::overrideRecord(const mwmp::NpcRecord& record)
         if (record.baseOverrides.hasAutoCalc)
         {
             finalData.mNpdtType = recordData.mNpdtType;
-
-            if ((recordData.mFlags & ESM::NPC::Autocalc) != 0)
-                finalData.mFlags |= ESM::NPC::Autocalc;
-            else
-                finalData.mFlags &= ~ESM::NPC::Autocalc;
+            Utils::setFlag(finalData.mFlags, ESM::NPC::Autocalc, recordData.mFlags);
         }
 
         if (!record.inventoryBaseId.empty() && doesRecordIdExist<ESM::NPC>(record.inventoryBaseId))

--- a/components/openmw-mp/Base/BaseWorldstate.hpp
+++ b/components/openmw-mp/Base/BaseWorldstate.hpp
@@ -145,6 +145,9 @@ namespace mwmp
         bool hasFog = false;
         bool hasWaterState = false;
         bool hasWaterLevel = false;
+        bool hasNoSleep = false;
+        bool hasQuasiEx = false;
+        bool hasRegion = false;
 
     };
 

--- a/components/openmw-mp/Base/BaseWorldstate.hpp
+++ b/components/openmw-mp/Base/BaseWorldstate.hpp
@@ -138,6 +138,11 @@ namespace mwmp
         bool hasCloseSound = false;
 
         bool hasScriptText = false;
+
+        bool hasHasAmbi = true;
+        bool hasAmbientColor = true;
+        bool hasSunlightColor = true;
+        bool hasFog = true;
     };
 
     struct ActivatorRecord

--- a/components/openmw-mp/Base/BaseWorldstate.hpp
+++ b/components/openmw-mp/Base/BaseWorldstate.hpp
@@ -139,11 +139,11 @@ namespace mwmp
 
         bool hasScriptText = false;
 
-        bool hasHasAmbi = false;
+        bool hasAmbiState = false;
         bool hasAmbientColor = false;
         bool hasSunlightColor = false;
         bool hasFog = false;
-        bool hasHasWater = false;
+        bool hasWaterState = false;
         bool hasWaterLevel = false;
 
     };

--- a/components/openmw-mp/Base/BaseWorldstate.hpp
+++ b/components/openmw-mp/Base/BaseWorldstate.hpp
@@ -139,10 +139,10 @@ namespace mwmp
 
         bool hasScriptText = false;
 
-        bool hasHasAmbi = true;
-        bool hasAmbientColor = true;
-        bool hasSunlightColor = true;
-        bool hasFog = true;
+        bool hasHasAmbi = false;
+        bool hasAmbientColor = false;
+        bool hasSunlightColor = false;
+        bool hasFog = false;
     };
 
     struct ActivatorRecord

--- a/components/openmw-mp/Base/BaseWorldstate.hpp
+++ b/components/openmw-mp/Base/BaseWorldstate.hpp
@@ -143,6 +143,9 @@ namespace mwmp
         bool hasAmbientColor = false;
         bool hasSunlightColor = false;
         bool hasFog = false;
+        bool hasHasWater = false;
+        bool hasWaterLevel = false;
+
     };
 
     struct ActivatorRecord

--- a/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
+++ b/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
@@ -495,13 +495,13 @@ void PacketRecordDynamic::Packet(RakNet::BitStream *newBitstream, bool send)
 
             RW(record.baseId, send, true);
             RW(recordData.mName, send, true);
-            RW(recordData.mHasAmbi, send, true);
+            RW(recordData.mHasAmbi, send);
             RW(recordData.mAmbi.mAmbient, send, true);
             RW(recordData.mAmbi.mSunlight, send, true);
             RW(recordData.mAmbi.mFog, send, true);
-            RW(recordData.mAmbi.mFogDensity, send, true);
-            RW(recordData.mData.mFlags, send, true);
-            RW(recordData.mWater, send, true);
+            RW(recordData.mAmbi.mFogDensity, send);
+            RW(recordData.mData.mFlags, send);
+            RW(recordData.mWater, send);
 
             if (!record.baseId.empty())
             {

--- a/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
+++ b/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
@@ -495,6 +495,23 @@ void PacketRecordDynamic::Packet(RakNet::BitStream *newBitstream, bool send)
 
             RW(record.baseId, send, true);
             RW(recordData.mName, send, true);
+            RW(recordData.mHasAmbi, send, true);
+            // don't send ambient lighting information to fix black lighting in cell records that lack this information
+            if (recordData.mHasAmbi) {
+                RW(recordData.mAmbi.mAmbient, send, true);
+                RW(recordData.mAmbi.mSunlight, send, true);
+                RW(recordData.mAmbi.mFog, send, true);
+                RW(recordData.mAmbi.mFogDensity, send, true);
+            }
+
+            if (!record.baseId.empty())
+            {
+                auto&& overrides = record.baseOverrides;
+                RW(overrides.hasHasAmbi, send);
+                RW(overrides.hasAmbientColor, send);
+                RW(overrides.hasSunlightColor, send);
+                RW(overrides.hasFog, send);
+            }
         }
     }
     else if (worldstate->recordsType == mwmp::RECORD_TYPE::CONTAINER)

--- a/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
+++ b/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
@@ -510,6 +510,8 @@ void PacketRecordDynamic::Packet(RakNet::BitStream *newBitstream, bool send)
                 RW(overrides.hasAmbientColor, send);
                 RW(overrides.hasSunlightColor, send);
                 RW(overrides.hasFog, send);
+                RW(overrides.hasHasWater, send);
+                RW(overrides.hasWaterLevel, send);
             }
         }
     }

--- a/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
+++ b/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
@@ -496,13 +496,12 @@ void PacketRecordDynamic::Packet(RakNet::BitStream *newBitstream, bool send)
             RW(record.baseId, send, true);
             RW(recordData.mName, send, true);
             RW(recordData.mHasAmbi, send, true);
-            // don't send ambient lighting information to fix black lighting in cell records that lack this information
-            if (recordData.mHasAmbi) {
-                RW(recordData.mAmbi.mAmbient, send, true);
-                RW(recordData.mAmbi.mSunlight, send, true);
-                RW(recordData.mAmbi.mFog, send, true);
-                RW(recordData.mAmbi.mFogDensity, send, true);
-            }
+            RW(recordData.mAmbi.mAmbient, send, true);
+            RW(recordData.mAmbi.mSunlight, send, true);
+            RW(recordData.mAmbi.mFog, send, true);
+            RW(recordData.mAmbi.mFogDensity, send, true);
+            RW(recordData.mData.mFlags, send, true);
+            RW(recordData.mWater, send, true);
 
             if (!record.baseId.empty())
             {

--- a/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
+++ b/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
@@ -512,6 +512,9 @@ void PacketRecordDynamic::Packet(RakNet::BitStream *newBitstream, bool send)
                 RW(overrides.hasFog, send);
                 RW(overrides.hasWaterState, send);
                 RW(overrides.hasWaterLevel, send);
+                RW(overrides.hasNoSleep, send);
+                RW(overrides.hasQuasiEx, send);
+                RW(overrides.hasRegion, send);
             }
         }
     }

--- a/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
+++ b/components/openmw-mp/Packets/Worldstate/PacketRecordDynamic.cpp
@@ -506,11 +506,11 @@ void PacketRecordDynamic::Packet(RakNet::BitStream *newBitstream, bool send)
             if (!record.baseId.empty())
             {
                 auto&& overrides = record.baseOverrides;
-                RW(overrides.hasHasAmbi, send);
+                RW(overrides.hasAmbiState, send);
                 RW(overrides.hasAmbientColor, send);
                 RW(overrides.hasSunlightColor, send);
                 RW(overrides.hasFog, send);
-                RW(overrides.hasHasWater, send);
+                RW(overrides.hasWaterState, send);
                 RW(overrides.hasWaterLevel, send);
             }
         }

--- a/components/openmw-mp/Utils.hpp
+++ b/components/openmw-mp/Utils.hpp
@@ -65,5 +65,21 @@ namespace Utils
 
     std::string intToHexStr(unsigned val);
     unsigned int hexStrToInt(std::string hexString);
+
+    template<typename T, typename E>
+    void setFlag(T& flags, E bit, bool value) {
+        if (value)
+            flags |= bit;
+        else
+            flags &= ~bit;
+    }
+
+    template<typename T, typename E>
+    void setFlag(T& flags, E bit, T source) {
+        if (source & bit)
+            flags |= bit;
+        else
+            flags &= ~bit;
+    }
 }
 #endif //UTILS_HPP


### PR DESCRIPTION
Fixes for ambient lighting, interior-as-exterior, and water level in dynamic cell records by uramer.

NOTE: These changes cannot be merged without the corresponding fixes in corescripts, https://github.com/DreamWeave-MP/CoreScripts/pull/22