### PR TITLE
Feat(scripting): Add script function to set player who cast a spell effect on another

### DIFF
--- a/apps/openmw-mp/Script/Functions/Spells.cpp
+++ b/apps/openmw-mp/Script/Functions/Spells.cpp
@@ -8,6 +8,7 @@
 
 using namespace mwmp;
 
+Player* storedPlayerCaster;
 std::vector<ESM::ActiveEffect> storedActiveEffects;
 
 void SpellFunctions::ClearSpellbookChanges(unsigned short pid) noexcept
@@ -112,8 +113,15 @@ void SpellFunctions::AddSpellActive(unsigned short pid, const char* spellId, con
     spell.params.mDisplayName = displayName;
     spell.params.mEffects = storedActiveEffects;
 
+    if (storedPlayerCaster != nullptr)
+    {
+        spell.caster.isPlayer = true;
+        spell.caster.guid = storedPlayerCaster->guid;
+    }
+
     player->spellsActiveChanges.activeSpells.push_back(spell);
 
+    storedPlayerCaster = nullptr;
     storedActiveEffects.clear();
 }
 
@@ -346,6 +354,11 @@ double SpellFunctions::GetCooldownStartHour(unsigned short pid, unsigned int ind
         return 0.0;
 
     return player->cooldownChanges.at(index).startTimestampHour;
+}
+
+void SpellFunctions::SetSpellsActiveCasterPid(unsigned short casterPid) noexcept
+{
+    storedPlayerCaster = Players::getPlayer(casterPid);
 }
 
 void SpellFunctions::SendSpellbookChanges(unsigned short pid, bool sendToOtherPlayers, bool skipAttachedPlayer) noexcept

--- a/apps/openmw-mp/Script/Functions/Spells.hpp
+++ b/apps/openmw-mp/Script/Functions/Spells.hpp
@@ -41,6 +41,8 @@
     {"GetCooldownStartDay",              SpellFunctions::GetCooldownStartDay},\
     {"GetCooldownStartHour",             SpellFunctions::GetCooldownStartHour},\
     \
+    {"SetSpellsActiveCasterPid",         SpellFunctions::SetSpellsActiveCasterPid},\
+    \
     {"SendSpellbookChanges",             SpellFunctions::SendSpellbookChanges},\
     {"SendSpellsActiveChanges",          SpellFunctions::SendSpellsActiveChanges},\
     {"SendCooldownChanges",              SpellFunctions::SendCooldownChanges},\
@@ -352,6 +354,13 @@ public:
     * \return The starting hour of the cooldown.
     */
     static double GetCooldownStartHour(unsigned short pid, unsigned int index) noexcept;
+
+    /**
+    * \brief Set a player ID as the caster of the next active spell that will be added to a player.
+    *
+    * \param casterPid The player ID of the caster.
+    */
+    static void SetSpellsActiveCasterPid(unsigned short casterPid) noexcept;
 
     /**
     * \brief Send a PlayerSpellbook packet with a player's recorded spellbook changes.


### PR DESCRIPTION
Found hiding in the source code of the no map marker build. Currently untested, but seems to be a working setter for `GetSpellsActiveCasterPid`