### PR TITLE
(Client): Sync additional AI package types

### DIFF
--- a/apps/openmw/mwmp/ActorList.cpp
+++ b/apps/openmw/mwmp/ActorList.cpp
@@ -91,13 +91,15 @@ void ActorList::addAiActor(BaseActor baseActor)
 void ActorList::addAiActor(const MWWorld::Ptr& actorPtr, const MWWorld::Ptr& targetPtr, unsigned int aiAction)
 {
     mwmp::BaseActor baseActor;
+    baseActor.refId  = actorPtr.getCellRef().getRefId();
     baseActor.refNum = actorPtr.getCellRef().getRefNum().mIndex;
     baseActor.mpNum = actorPtr.getCellRef().getMpNum();
+
     baseActor.aiAction = aiAction;
     baseActor.aiTarget = MechanicsHelper::getTarget(targetPtr);
 
     LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "Preparing to send ID_ACTOR_AI about %s %i-%i\n- action: %i",
-        actorPtr.getCellRef().getRefId().c_str(), baseActor.refNum, baseActor.mpNum, aiAction);
+                       baseActor.refId.c_str(), baseActor.refNum, baseActor.mpNum, aiAction);
 
     if (baseActor.aiTarget.isPlayer)
     {
@@ -127,39 +129,6 @@ void ActorList::addAttackActor(const MWWorld::Ptr& actorPtr, const mwmp::Attack 
     attackActors.push_back(baseActor);
 }
 
-void ActorList::addTravelActor(const MWWorld::Ptr &actorPtr, ESM::Position coordinates)
-{
-    mwmp::BaseActor baseActor;
-    baseActor.refNum = actorPtr.getCellRef().getRefNum().mIndex;
-    baseActor.mpNum = actorPtr.getCellRef().getMpNum();
-    baseActor.aiAction = mwmp::BaseActorList::TRAVEL;
-
-    baseActor.aiCoordinates = coordinates;
-
-    LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "Preparing to send ID_ACTOR_AI about %s %i-%i\n- action: %i",
-        actorPtr.getCellRef().getRefId().c_str(), baseActor.refNum, baseActor.mpNum, baseActor.aiAction);
-
-    addAiActor(baseActor);
-}
-
-void ActorList::addWanderActor(const MWWorld::Ptr& actorPtr, unsigned int distance, unsigned int duration, bool repeat)
-{
-    mwmp::BaseActor baseActor;
-    baseActor.refNum = actorPtr.getCellRef().getRefNum().mIndex;
-    baseActor.mpNum = actorPtr.getCellRef().getMpNum();
-    baseActor.aiAction = mwmp::BaseActorList::WANDER;
-
-    baseActor.aiDuration = duration;
-    baseActor.aiDistance = distance;
-    baseActor.aiShouldRepeat = repeat;
-
-
-    LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "Preparing to send ID_ACTOR_AI about %s %i-%i\n- action: %i",
-                       actorPtr.getCellRef().getRefId().c_str(), baseActor.refNum, baseActor.mpNum, baseActor.aiAction);
-
-    addAiActor(baseActor);
-}
-
 void ActorList::addCastActor(BaseActor baseActor)
 {
     castActors.push_back(baseActor);
@@ -168,6 +137,25 @@ void ActorList::addCastActor(BaseActor baseActor)
 void ActorList::addCellChangeActor(BaseActor baseActor)
 {
     cellChangeActors.push_back(baseActor);
+}
+
+void ActorList::queueAiActor(BaseActor baseActor) {
+    LOG_MESSAGE_SIMPLE(
+        TimedLog::LOG_INFO,
+        "Preparing to send ID_ACTOR_AI about %s %i-%i\n- action: %i",
+        baseActor.refId.c_str(), baseActor.refNum, baseActor.mpNum,
+        baseActor.aiAction);
+
+    if (baseActor.aiTarget.isPlayer) {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "- Has player target %s",
+                           baseActor.aiTarget.refId.c_str());
+    } else {
+        LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "- Has actor target %s %i-%i",
+                           baseActor.aiTarget.refId.c_str(),
+                           baseActor.aiTarget.refNum, baseActor.aiTarget.mpNum);
+    }
+
+    addAiActor(baseActor);
 }
 
 void ActorList::sendPositionActors()

--- a/apps/openmw/mwmp/ActorList.cpp
+++ b/apps/openmw/mwmp/ActorList.cpp
@@ -127,12 +127,28 @@ void ActorList::addAttackActor(const MWWorld::Ptr& actorPtr, const mwmp::Attack 
     attackActors.push_back(baseActor);
 }
 
+void ActorList::addTravelActor(const MWWorld::Ptr &actorPtr, ESM::Position coordinates)
+{
+    mwmp::BaseActor baseActor;
+    baseActor.refNum = actorPtr.getCellRef().getRefNum().mIndex;
+    baseActor.mpNum = actorPtr.getCellRef().getMpNum();
+    baseActor.aiAction = mwmp::BaseActorList::TRAVEL;
+
+    baseActor.aiCoordinates = coordinates;
+
+    LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "Preparing to send ID_ACTOR_AI about %s %i-%i\n- action: %i",
+        actorPtr.getCellRef().getRefId().c_str(), baseActor.refNum, baseActor.mpNum, baseActor.aiAction);
+
+    addAiActor(baseActor);
+}
+
 void ActorList::addWanderActor(const MWWorld::Ptr& actorPtr, unsigned int distance, unsigned int duration, bool repeat)
 {
     mwmp::BaseActor baseActor;
     baseActor.refNum = actorPtr.getCellRef().getRefNum().mIndex;
     baseActor.mpNum = actorPtr.getCellRef().getMpNum();
     baseActor.aiAction = mwmp::BaseActorList::WANDER;
+
     baseActor.aiDuration = duration;
     baseActor.aiDistance = distance;
     baseActor.aiShouldRepeat = repeat;

--- a/apps/openmw/mwmp/ActorList.cpp
+++ b/apps/openmw/mwmp/ActorList.cpp
@@ -127,6 +127,23 @@ void ActorList::addAttackActor(const MWWorld::Ptr& actorPtr, const mwmp::Attack 
     attackActors.push_back(baseActor);
 }
 
+void ActorList::addWanderActor(const MWWorld::Ptr& actorPtr, unsigned int distance, unsigned int duration, bool repeat)
+{
+    mwmp::BaseActor baseActor;
+    baseActor.refNum = actorPtr.getCellRef().getRefNum().mIndex;
+    baseActor.mpNum = actorPtr.getCellRef().getMpNum();
+    baseActor.aiAction = mwmp::BaseActorList::WANDER;
+    baseActor.aiDuration = duration;
+    baseActor.aiDistance = distance;
+    baseActor.aiShouldRepeat = repeat;
+
+
+    LOG_MESSAGE_SIMPLE(TimedLog::LOG_INFO, "Preparing to send ID_ACTOR_AI about %s %i-%i\n- action: %i",
+                       actorPtr.getCellRef().getRefId().c_str(), baseActor.refNum, baseActor.mpNum, baseActor.aiAction);
+
+    addAiActor(baseActor);
+}
+
 void ActorList::addCastActor(BaseActor baseActor)
 {
     castActors.push_back(baseActor);

--- a/apps/openmw/mwmp/ActorList.hpp
+++ b/apps/openmw/mwmp/ActorList.hpp
@@ -32,6 +32,7 @@ namespace mwmp
         void addAttackActor(BaseActor baseActor);
         void addAttackActor(const MWWorld::Ptr& actorPtr, const mwmp::Attack &attack);
         void addWanderActor(const MWWorld::Ptr& actorPtr, unsigned int distance, unsigned int duration, bool repeat);
+        void addTravelActor(const MWWorld::Ptr& actorPtr, ESM::Position coordinates);
         void addCastActor(BaseActor baseActor);
         void addCellChangeActor(BaseActor baseActor);
 

--- a/apps/openmw/mwmp/ActorList.hpp
+++ b/apps/openmw/mwmp/ActorList.hpp
@@ -31,10 +31,9 @@ namespace mwmp
         void addAiActor(const MWWorld::Ptr& actorPtr, const MWWorld::Ptr& targetPtr, unsigned int aiAction);
         void addAttackActor(BaseActor baseActor);
         void addAttackActor(const MWWorld::Ptr& actorPtr, const mwmp::Attack &attack);
-        void addWanderActor(const MWWorld::Ptr& actorPtr, unsigned int distance, unsigned int duration, bool repeat);
-        void addTravelActor(const MWWorld::Ptr& actorPtr, ESM::Position coordinates);
         void addCastActor(BaseActor baseActor);
         void addCellChangeActor(BaseActor baseActor);
+        void queueAiActor(BaseActor baseActor);
 
         void sendPositionActors();
         void sendAnimFlagsActors();

--- a/apps/openmw/mwmp/ActorList.hpp
+++ b/apps/openmw/mwmp/ActorList.hpp
@@ -31,6 +31,7 @@ namespace mwmp
         void addAiActor(const MWWorld::Ptr& actorPtr, const MWWorld::Ptr& targetPtr, unsigned int aiAction);
         void addAttackActor(BaseActor baseActor);
         void addAttackActor(const MWWorld::Ptr& actorPtr, const mwmp::Attack &attack);
+        void addWanderActor(const MWWorld::Ptr& actorPtr, unsigned int distance, unsigned int duration, bool repeat);
         void addCastActor(BaseActor baseActor);
         void addCellChangeActor(BaseActor baseActor);
 

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -80,10 +80,18 @@ namespace MWScript
 
                     if (targetPtr)
                         {
+                            // Common Logic
                             mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                            mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                             actorList->reset();
                             actorList->cell = *ptr.getCell()->getCell();
-                            actorList->addAiActor(ptr, targetPtr, mwmp::BaseActorList::ACTIVATE);
+
+                            // Package-specific logic
+                            baseActor.aiTarget = MechanicsHelper::getTarget(targetPtr);
+                            baseActor.aiAction = mwmp::BaseActorList::ACTIVATE;
+
+                            // Send it
+                            actorList->queueAiActor(baseActor);
                             actorList->sendAiActors();
                         }
                     /*
@@ -121,20 +129,26 @@ namespace MWScript
                     /*
                       Start of tes3mp addition
 
-                      Send ActorAI packets when an actor becomes a follower,
+                      Send ActorAI packets when an actor begins travelling,
                       regardless of whether we're the cell authority or not; the
                       server can decide if it wants to comply with them by
                       forwarding them to the cell authority
                     */
-                    ESM::Position position;
-                    position.pos[0] = x;
-                    position.pos[1] = y;
-                    position.pos[2] = z;
 
+                    // Common Logic
                     mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                    mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                     actorList->reset();
                     actorList->cell = *ptr.getCell()->getCell();
-                    actorList->addTravelActor(ptr, position);
+
+                    // Package-Specific logic
+                    baseActor.aiCoordinates.pos[0] = x;
+                    baseActor.aiCoordinates.pos[1] = y;
+                    baseActor.aiCoordinates.pos[2] = z;
+                    baseActor.aiAction = mwmp::BaseActorList::TRAVEL;
+
+                    // Send it
+                    actorList->queueAiActor(baseActor);
                     actorList->sendAiActors();
                     /*
                         End of tes3mp addition
@@ -289,14 +303,25 @@ namespace MWScript
                     /*
                       Start of tes3mp addition
 
-                      Send ActorAI packets when an actor becomes a follower, regardless of whether we're
+                      Send ActorAI packets when an actor starts wandering, regardless of whether we're
                       the cell authority or not; the server can decide if it wants to comply with them by
                       forwarding them to the cell authority
                     */
+
+                    // Common Logic
                     mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                    mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                     actorList->reset();
                     actorList->cell = *ptr.getCell()->getCell();
-                    actorList->addWanderActor(ptr, range, duration, repeat);
+
+                    // Package-specific logic
+                    baseActor.aiDuration = duration;
+                    baseActor.aiDistance = range;
+                    baseActor.aiShouldRepeat = repeat;
+                    baseActor.aiAction = mwmp::BaseActorList::WANDER;
+
+                    // Send it
+                    actorList->queueAiActor(baseActor);
                     actorList->sendAiActors();
                     /*
                         End of tes3mp addition

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -241,6 +241,22 @@ namespace MWScript
 
                     MWMechanics::AiWander wanderPackage(range, duration, time, idleList, repeat);
                     ptr.getClass().getCreatureStats (ptr).getAiSequence().stack(wanderPackage, ptr);
+
+                    /*
+                      Start of tes3mp addition
+
+                      Send ActorAI packets when an actor becomes a follower, regardless of whether we're
+                      the cell authority or not; the server can decide if it wants to comply with them by
+                      forwarding them to the cell authority
+                    */
+                    mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                    actorList->reset();
+                    actorList->cell = *ptr.getCell()->getCell();
+                    actorList->addWanderActor(ptr, range, duration, repeat);
+                    actorList->sendAiActors();
+                    /*
+                        End of tes3mp addition
+                    */
                 }
         };
 

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -67,6 +67,28 @@ namespace MWScript
                     MWMechanics::AiActivate activatePackage(objectID);
                     ptr.getClass().getCreatureStats (ptr).getAiSequence().stack(activatePackage, ptr);
                     Log(Debug::Info) << "AiActivate";
+
+                    /*
+                      Start of tes3mp addition
+
+                      Send ActorAI packets when an actor becomes a follower,
+                      regardless of whether we're the cell authority or not; the
+                      server can decide if it wants to comply with them by
+                      forwarding them to the cell authority
+                    */
+                    MWWorld::Ptr targetPtr = MWBase::Environment::get().getWorld()->searchPtr(objectID, true);
+
+                    if (targetPtr)
+                        {
+                            mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                            actorList->reset();
+                            actorList->cell = *ptr.getCell()->getCell();
+                            actorList->addAiActor(ptr, targetPtr, mwmp::BaseActorList::ACTIVATE);
+                            actorList->sendAiActors();
+                        }
+                    /*
+                        End of tes3mp addition
+                    */
                 }
         };
 

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -187,6 +187,39 @@ namespace MWScript
                     ptr.getClass().getCreatureStats (ptr).getAiSequence().stack(escortPackage, ptr);
 
                     Log(Debug::Info) << "AiEscort: " << x << ", " << y << ", " << z << ", " << duration;
+
+                    /*
+                        Start of tes3mp addition
+
+                        Send ActorAI packets when an actor begins escorting, regardless of whether we're
+                        the cell authority or not; the server can decide if it wants to comply with them by
+                        forwarding them to the cell authority
+                    */
+                    MWWorld::Ptr targetPtr = MWBase::Environment::get().getWorld()->searchPtr(actorID, true);
+
+                    if (targetPtr)
+                        {
+                            // Common Logic
+                            mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                            mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
+                            actorList->reset();
+                            actorList->cell = *ptr.getCell()->getCell();
+                            baseActor.aiAction = mwmp::BaseActorList::ESCORT;
+
+                            // Package-specific logic
+                            baseActor.aiCoordinates.pos[0] = x;
+                            baseActor.aiCoordinates.pos[1] = y;
+                            baseActor.aiCoordinates.pos[2] = z;
+                            baseActor.aiDuration = duration;
+                            baseActor.aiTarget = MechanicsHelper::getTarget(targetPtr);
+
+                            // Send it
+                            actorList->queueAiActor(baseActor);
+                            actorList->sendAiActors();
+                        }
+                    /*
+                      End of tes3mp addition
+                    */
                 }
         };
 

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -69,7 +69,7 @@ namespace MWScript
                     Log(Debug::Info) << "AiActivate";
 
                     /*
-                      Start of tes3mp addition
+                      Start of dreamweave addition
 
                       Send ActorAI packets when an actor becomes a follower,
                       regardless of whether we're the cell authority or not; the
@@ -95,7 +95,7 @@ namespace MWScript
                             actorList->sendAiActors();
                         }
                     /*
-                        End of tes3mp addition
+                        End of dreamweave addition
                     */
                 }
         };
@@ -127,7 +127,7 @@ namespace MWScript
                     Log(Debug::Info) << "AiTravel: " << x << ", " << y << ", " << z;
 
                     /*
-                      Start of tes3mp addition
+                      Start of dreamweave addition
 
                       Send ActorAI packets when an actor begins travelling,
                       regardless of whether we're the cell authority or not; the
@@ -151,7 +151,7 @@ namespace MWScript
                     actorList->queueAiActor(baseActor);
                     actorList->sendAiActors();
                     /*
-                        End of tes3mp addition
+                        End of dreamweave addition
                     */
                 }
         };
@@ -189,7 +189,7 @@ namespace MWScript
                     Log(Debug::Info) << "AiEscort: " << x << ", " << y << ", " << z << ", " << duration;
 
                     /*
-                        Start of tes3mp addition
+                        Start of dreamweave addition
 
                         Send ActorAI packets when an actor begins escorting, regardless of whether we're
                         the cell authority or not; the server can decide if it wants to comply with them by
@@ -218,7 +218,7 @@ namespace MWScript
                             actorList->sendAiActors();
                         }
                     /*
-                      End of tes3mp addition
+                      End of dreamweave addition
                     */
                 }
         };
@@ -334,7 +334,7 @@ namespace MWScript
                     ptr.getClass().getCreatureStats (ptr).getAiSequence().stack(wanderPackage, ptr);
 
                     /*
-                      Start of tes3mp addition
+                      Start of dreamweave addition
 
                       Send ActorAI packets when an actor starts wandering, regardless of whether we're
                       the cell authority or not; the server can decide if it wants to comply with them by
@@ -357,7 +357,7 @@ namespace MWScript
                     actorList->queueAiActor(baseActor);
                     actorList->sendAiActors();
                     /*
-                        End of tes3mp addition
+                        End of dreamweave addition
                     */
                 }
         };

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -430,10 +430,22 @@ namespace MWScript
 
                     if (targetPtr)
                     {
+                        // Common Logic
                         mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                        mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                         actorList->reset();
                         actorList->cell = *ptr.getCell()->getCell();
-                        actorList->addAiActor(ptr, targetPtr, mwmp::BaseActorList::FOLLOW);
+
+                        // Package-specific logic
+                        baseActor.aiCoordinates.pos[0] = x;
+                        baseActor.aiCoordinates.pos[1] = y;
+                        baseActor.aiCoordinates.pos[2] = z;
+
+                        baseActor.aiAction = mwmp::BaseActorList::FOLLOW;
+                        baseActor.aiTarget = MechanicsHelper::getTarget(targetPtr);
+
+                        // Send it
+                        actorList->queueAiActor(baseActor);
                         actorList->sendAiActors();
                     }
                     /*

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -95,6 +95,28 @@ namespace MWScript
                     ptr.getClass().getCreatureStats (ptr).getAiSequence().stack(travelPackage, ptr);
 
                     Log(Debug::Info) << "AiTravel: " << x << ", " << y << ", " << z;
+
+                    /*
+                      Start of tes3mp addition
+
+                      Send ActorAI packets when an actor becomes a follower,
+                      regardless of whether we're the cell authority or not; the
+                      server can decide if it wants to comply with them by
+                      forwarding them to the cell authority
+                    */
+                    ESM::Position position;
+                    position.pos[0] = x;
+                    position.pos[1] = y;
+                    position.pos[2] = z;
+
+                    mwmp::ActorList *actorList = mwmp::Main::get().getNetworking()->getActorList();
+                    actorList->reset();
+                    actorList->cell = *ptr.getCell()->getCell();
+                    actorList->addTravelActor(ptr, position);
+                    actorList->sendAiActors();
+                    /*
+                        End of tes3mp addition
+                    */
                 }
         };
 

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -85,10 +85,10 @@ namespace MWScript
                             mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                             actorList->reset();
                             actorList->cell = *ptr.getCell()->getCell();
+                            baseActor.aiAction = mwmp::BaseActorList::ACTIVATE;
 
                             // Package-specific logic
                             baseActor.aiTarget = MechanicsHelper::getTarget(targetPtr);
-                            baseActor.aiAction = mwmp::BaseActorList::ACTIVATE;
 
                             // Send it
                             actorList->queueAiActor(baseActor);
@@ -140,12 +140,12 @@ namespace MWScript
                     mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                     actorList->reset();
                     actorList->cell = *ptr.getCell()->getCell();
+                    baseActor.aiAction = mwmp::BaseActorList::TRAVEL;
 
                     // Package-Specific logic
                     baseActor.aiCoordinates.pos[0] = x;
                     baseActor.aiCoordinates.pos[1] = y;
                     baseActor.aiCoordinates.pos[2] = z;
-                    baseActor.aiAction = mwmp::BaseActorList::TRAVEL;
 
                     // Send it
                     actorList->queueAiActor(baseActor);
@@ -313,12 +313,12 @@ namespace MWScript
                     mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                     actorList->reset();
                     actorList->cell = *ptr.getCell()->getCell();
+                    baseActor.aiAction = mwmp::BaseActorList::WANDER;
 
                     // Package-specific logic
                     baseActor.aiDuration = duration;
                     baseActor.aiDistance = range;
                     baseActor.aiShouldRepeat = repeat;
-                    baseActor.aiAction = mwmp::BaseActorList::WANDER;
 
                     // Send it
                     actorList->queueAiActor(baseActor);
@@ -460,13 +460,12 @@ namespace MWScript
                         mwmp::BaseActor baseActor = mwmp::BaseActor(ptr);
                         actorList->reset();
                         actorList->cell = *ptr.getCell()->getCell();
+                        baseActor.aiAction = mwmp::BaseActorList::FOLLOW;
 
                         // Package-specific logic
                         baseActor.aiCoordinates.pos[0] = x;
                         baseActor.aiCoordinates.pos[1] = y;
                         baseActor.aiCoordinates.pos[2] = z;
-
-                        baseActor.aiAction = mwmp::BaseActorList::FOLLOW;
                         baseActor.aiTarget = MechanicsHelper::getTarget(targetPtr);
 
                         // Send it

--- a/components/openmw-mp/Base/BaseActor.hpp
+++ b/components/openmw-mp/Base/BaseActor.hpp
@@ -7,6 +7,8 @@
 
 #include <RakNetTypes.h>
 
+#include <apps/openmw/mwworld/class.hpp>
+
 namespace mwmp
 {
     class BaseActor
@@ -17,6 +19,15 @@ namespace mwmp
         {
             hasPositionData = false;
             hasStatsDynamicData = false;
+        }
+
+        BaseActor(const MWWorld::Ptr &actorPtr)
+        {
+            hasPositionData = false;
+            hasStatsDynamicData = false;
+            this->refId = actorPtr.getCellRef().getRefId();
+            this->refNum = actorPtr.getCellRef().getRefNum().mIndex;
+            this->mpNum = actorPtr.getCellRef().getMpNum();
         }
 
         std::string refId = "";

--- a/components/openmw-mp/Packets/Actor/PacketActorAI.cpp
+++ b/components/openmw-mp/Packets/Actor/PacketActorAI.cpp
@@ -46,6 +46,7 @@ void PacketActorAI::Actor(BaseActor &actor, bool send)
                     RW(actor.aiTarget.refId, send, true);
                     RW(actor.aiTarget.refNum, send);
                     RW(actor.aiTarget.mpNum, send);
+                    RW(actor.aiTarget.name, send);
                 }
             }
         }

--- a/components/openmw-mp/Packets/Actor/PacketActorAI.cpp
+++ b/components/openmw-mp/Packets/Actor/PacketActorAI.cpp
@@ -24,7 +24,8 @@ void PacketActorAI::Actor(BaseActor &actor, bool send)
         if (actor.aiAction == mwmp::BaseActorList::ESCORT || actor.aiAction == mwmp::BaseActorList::WANDER)
             RW(actor.aiDuration, send);
 
-        if (actor.aiAction == mwmp::BaseActorList::ESCORT || actor.aiAction == mwmp::BaseActorList::TRAVEL)
+        if (actor.aiAction == mwmp::BaseActorList::ESCORT || actor.aiAction == mwmp::BaseActorList::TRAVEL ||
+            actor.aiAction == mwmp::BaseActorList::FOLLOW)
             RW(actor.aiCoordinates, send);
 
         if (actor.aiAction == mwmp::BaseActorList::ACTIVATE || actor.aiAction == mwmp::BaseActorList::COMBAT ||


### PR DESCRIPTION
#31 currently only half-works due to certain fields being missing, and certain ai packages not being sent by the client at all.

The goal of this PR is to:

1. Expose all available AI packages to the server, so that #31 is actually usable
2. Fill in additional fields which the engine core simply doesn't write, even though they exist in the data structure and #31 attempts to read them.

Current Status:
All ai packages except for FollowCell and EscortCell are currently implemented. 

The underlying code to support this functionality simply does not exist in the engine *quite* yet, as an additional Cell destination field needs to be defined in `BaseActor`, and the AI_ACTION enum needs to be extended to support them. After this has been done, another separate, but similar to #31, pull request may be made to expose those packages to the scripting api.

For now, this PR also does not handle authority in any way, shape or form, and thus may be broken in a live setting. Or, possibly not. 

Although its functionality is complete, consider this PR a draft until we've verified it doesn't do something stupid with cell authority (which, it probably does.)