### PR TITLE
cleanup(server): remove deprecated check

### DIFF
--- a/apps/openmw-mp/main.cpp
+++ b/apps/openmw-mp/main.cpp
@@ -281,15 +281,6 @@ int main(int argc, char *argv[])
             int masterPort = mgr.getInt("port", "MasterServer");
             int updateRate = mgr.getInt("rate", "MasterServer");
 
-            // Is this an attempt to connect to the official master server at the old port? If so,
-            // redirect it to the correct port for the currently used fork of RakNet
-            if (Misc::StringUtils::ciEqual(masterAddr, "master.tes3mp.com") && masterPort == 25560)
-            {
-                masterPort = 25561;
-                LOG_APPEND(TimedLog::LOG_INFO, "- switching to port %i because the correct official master server for this version is on that port",
-                    masterPort);
-            }
-
             if (updateRate < 8000)
             {
                 updateRate = 8000;


### PR DESCRIPTION
This code isn't usable for us anymore, as not only does it only work for the official server, it also was removed from our master.

The supporting code for this was removed here: #6 